### PR TITLE
fix: remove init flag redefinition

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -27,10 +27,6 @@ var InitCommand = cli.Command{
 			Usage: ".desktop files directory",
 		},
 		&cli.StringFlag{
-			Name:  "apps-desktop-dir",
-			Usage: ".desktop files directory",
-		},
-		&cli.StringFlag{
 			Name:  "apps-link-dir",
 			Usage: "AppImage symlinks directory",
 		},

--- a/utils/logging.go
+++ b/utils/logging.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/fatih/color"
@@ -16,7 +17,7 @@ var LogRightArrowPrefix = color.MagentaString(">")
 var LogTickPrefix = color.GreenString("√")
 var LogExclamationPrefix = color.RedString("!")
 
-var LogDebugEnabled = false
+var LogDebugEnabled = os.Getenv("DEBUG") == "1"
 
 func LogInfo(msg string) {
 	fmt.Println(msg)


### PR DESCRIPTION
remove redefinition of `apps-desktop-dir` which is currently causing panic when running `pho init`

```
$ pho init
init flag redefined: apps-desktop-dir
panic: init flag redefined: apps-desktop-dir
```