### PR TITLE
fix: empty path error when resolving appsLink

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -151,6 +151,8 @@ var InitCommand = cli.Command{
 					return err
 				}
 			}
+		}
+		if appsLinkDir != "" {
 			appsLinkDir, err = utils.ResolvePath(appsLinkDir)
 			if err != nil {
 				return err

--- a/commands/init.go
+++ b/commands/init.go
@@ -151,10 +151,10 @@ var InitCommand = cli.Command{
 					return err
 				}
 			}
-		}
-		appsLinkDir, err = utils.ResolvePath(appsLinkDir)
-		if err != nil {
-			return err
+			appsLinkDir, err = utils.ResolvePath(appsLinkDir)
+			if err != nil {
+				return err
+			}
 		}
 
 		if !enableIntegrationPromptSet && !assumeYes {


### PR DESCRIPTION
Currently `pho init` fails when symlinking is disabled,
because `utils.ResolvePath` always gets called even when the `appsLinkDir` string is empty.

This fixes it by moving the check into the if block, where `appsLinkDir` would actually be set.

---

I also made another change but I'm not sure if the feature should be added. I'll send a separate PR later, it's pretty late at night for me 😅