### PR TITLE
feat: try to extract `.png` icon

### DIFF
--- a/core/appimage.go
+++ b/core/appimage.go
@@ -74,7 +74,11 @@ func (deflated *DeflatedAppImage) ExtractExecName() (string, error) {
 func (metadata *DeflatedAppImageMetadata) CopyIconFile(paths *AppPaths) error {
 	src, err := os.Open(metadata.IconPath)
 	if err != nil {
-		return err
+		pngPath := path.Join(metadata.AppDir, fmt.Sprintf("%s.png", metadata.ExecName))
+		src, err = os.Open(pngPath)
+		if err != nil {
+			return err
+		}
 	}
 	defer src.Close()
 	dest, err := os.Create(paths.Icon)


### PR DESCRIPTION
This tries to extract `<ExecName>.png` if `.DirIcon` doesn't exist in the appimage.

I added this mainly because the appimage from [osu](https://github.com/ppy/osu) did not contain a `.DirIcon`, thus failing the installation with `pho`.

Though `.DirIcon` is the spec, I thought there might be some appimages that also has this problem,
so maybe this can be added to make app installation easier.

